### PR TITLE
Redo the project as a docker-maven-plugin project.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2016 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.redhat.ipaas.keycloak</groupId>
+  <artifactId>parent-openshift</artifactId>
+  <packaging>pom</packaging>
+  <name>iPaaS Keycloak parent</name>
+  <description>Keycloak customizations for iPaaS</description>
+  <version>0.1-SNAPSHOT</version>
+
+  <url>https://redhat.com/</url>
+  <inceptionYear>2016</inceptionYear>
+
+  <organization>
+    <name>Red Hat</name>
+    <url>https://redhat.com/</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <!-- including A developer as it's required by the maven poms going into
+    central -->
+  <developers>
+    <developer>
+      <id>geeks</id>
+      <name>Red Hat iPaaS Development Team</name>
+      <organization>Red Hat</organization>
+      <organizationUrl>https://redhat.com/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git@github.com:redhat-ipaas/keycloak-customizations.git</connection>
+    <developerConnection>scm:git:git@github.com:redhat-ipaas/keycloak-customizations.git</developerConnection>
+    <url>http://github.com/redhat-ipaas/keycloak-customizations/</url>
+    <tag>${project.version}</tag>
+  </scm>
+
+  <properties>
+    <keycloak-customizations.version>0.1.0.fuse-000003</keycloak-customizations.version>
+    <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
+    <docker.maven.plugin.fabric8.version>0.22.1</docker.maven.plugin.fabric8.version>
+
+    <keycloak.customizations.location>.</keycloak.customizations.location>
+    <keycloak.version>2.5.4.Final</keycloak.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.redhat.ipaas.keycloak.authenticators</groupId>
+        <artifactId>autolink-idp</artifactId>
+        <version>${keycloak-customizations.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.redhat.ipaas.keycloak.providers</groupId>
+        <artifactId>openshift</artifactId>
+        <version>${keycloak-customizations.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.redhat.ipaas.keycloak</groupId>
+        <artifactId>theme</artifactId>
+        <version>${keycloak-customizations.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.redhat.ipaas.keycloak.authenticators</groupId>
+                  <artifactId>autolink-idp</artifactId>
+                  <destFileName>autolink-idp.jar</destFileName>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.redhat.ipaas.keycloak.providers</groupId>
+                  <artifactId>openshift</artifactId>
+                  <destFileName>openshift-provider.jar</destFileName>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.redhat.ipaas.keycloak</groupId>
+                  <artifactId>theme</artifactId>
+                  <destFileName>ipaas-theme.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.basedir}/src/main/docker</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>${docker.maven.plugin.fabric8.version}</version>
+        <configuration>
+          <id>copy</id>
+          <phase>package</phase>
+          <goals>
+            <goal>build</goal>
+          </goals>
+          <images>
+            <image>
+              <name>syndesisio/${project.artifactId}</name>
+              <build>
+<!--                <dockerFile>../src/main/docker/Dockerfile</dockerFile>
+                <dockerFileDir>${project.basedir}/target</dockerFileDir>-->
+              </build>
+            </image>
+          </images>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
   <groupId>io.syndesis</groupId>
   <artifactId>parent-keycloak-openshift</artifactId>
   <packaging>pom</packaging>
-  <name>iPaaS Keycloak Openshift parent</name>
-  <description>Keycloak Openshift for iPaaS</description>
+  <name>Syndesis Keycloak Openshift parent</name>
+  <description>Keycloak server for Openshift</description>
   <version>0.1-SNAPSHOT</version>
 
   <url>https://redhat.com/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
   <groupId>com.redhat.ipaas.keycloak</groupId>
   <artifactId>parent-openshift</artifactId>
   <packaging>pom</packaging>
-  <name>iPaaS Keycloak parent</name>
-  <description>Keycloak customizations for iPaaS</description>
+  <name>iPaaS Keycloak Openshift parent</name>
+  <description>Keycloak Openshift for iPaaS</description>
   <version>0.1-SNAPSHOT</version>
 
   <url>https://redhat.com/</url>
@@ -56,9 +56,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git@github.com:redhat-ipaas/keycloak-customizations.git</connection>
-    <developerConnection>scm:git:git@github.com:redhat-ipaas/keycloak-customizations.git</developerConnection>
-    <url>http://github.com/redhat-ipaas/keycloak-customizations/</url>
+    <connection>scm:git:git@github.com:syndesisio/keycloak-openshift.git</connection>
+    <developerConnection>scm:git:git@github.com:syndesisio/keycloak-openshift.git</developerConnection>
+    <url>http://github.com/syndesisio/keycloak-openshift/</url>
     <tag>${project.version}</tag>
   </scm>
 
@@ -144,12 +144,34 @@
             <image>
               <name>syndesisio/${project.artifactId}</name>
               <build>
-<!--                <dockerFile>../src/main/docker/Dockerfile</dockerFile>
-                <dockerFileDir>${project.basedir}/target</dockerFileDir>-->
               </build>
             </image>
           </images>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.2</version>
+        <executions>
+          <execution>
+            <id>auto-clean</id>
+            <phase>package</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>${project.basedir}/src/main/docker</directory>
+                  <includes>
+                    <include>*.jar</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.redhat.ipaas.keycloak</groupId>
-  <artifactId>parent-openshift</artifactId>
+  <groupId>io.syndesis</groupId>
+  <artifactId>parent-keycloak-openshift</artifactId>
   <packaging>pom</packaging>
   <name>iPaaS Keycloak Openshift parent</name>
   <description>Keycloak Openshift for iPaaS</description>
@@ -49,9 +49,9 @@
   <developers>
     <developer>
       <id>geeks</id>
-      <name>Red Hat iPaaS Development Team</name>
-      <organization>Red Hat</organization>
-      <organizationUrl>https://redhat.com/</organizationUrl>
+      <name>Syndesis Development Team</name>
+      <organization>Syndesis</organization>
+      <organizationUrl>https://syndesis.io</organizationUrl>
     </developer>
   </developers>
 
@@ -63,7 +63,7 @@
   </scm>
 
   <properties>
-    <keycloak-customizations.version>0.1.0.fuse-000003</keycloak-customizations.version>
+    <keycloak-customizations.version>0.1-SNAPSHOT</keycloak-customizations.version>
     <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
     <docker.maven.plugin.fabric8.version>0.22.1</docker.maven.plugin.fabric8.version>
 
@@ -74,17 +74,17 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.redhat.ipaas.keycloak.authenticators</groupId>
+        <groupId>io.syndesis.keycloak.authenticators</groupId>
         <artifactId>autolink-idp</artifactId>
         <version>${keycloak-customizations.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.redhat.ipaas.keycloak.providers</groupId>
+        <groupId>io.syndesis.keycloak.providers</groupId>
         <artifactId>openshift</artifactId>
         <version>${keycloak-customizations.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.redhat.ipaas.keycloak</groupId>
+        <groupId>io.syndesis.keycloak</groupId>
         <artifactId>theme</artifactId>
         <version>${keycloak-customizations.version}</version>
       </dependency>
@@ -107,17 +107,17 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>com.redhat.ipaas.keycloak.authenticators</groupId>
+                  <groupId>io.syndesis.keycloak.authenticators</groupId>
                   <artifactId>autolink-idp</artifactId>
                   <destFileName>autolink-idp.jar</destFileName>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>com.redhat.ipaas.keycloak.providers</groupId>
+                  <groupId>io.syndesis.keycloak.providers</groupId>
                   <artifactId>openshift</artifactId>
                   <destFileName>openshift-provider.jar</destFileName>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>com.redhat.ipaas.keycloak</groupId>
+                  <groupId>io.syndesis.keycloak</groupId>
                   <artifactId>theme</artifactId>
                   <destFileName>ipaas-theme.jar</destFileName>
                 </artifactItem>
@@ -144,19 +144,19 @@
             <image>
               <name>syndesisio/${project.artifactId}</name>
               <build>
+                <dockerFile>DockerFile</dockerFile>
               </build>
             </image>
           </images>
         </configuration>
       </plugin>
-
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
         <version>2.2</version>
         <executions>
           <execution>
             <id>auto-clean</id>
-            <phase>package</phase>
+            <phase>install</phase>
             <goals>
               <goal>clean</goal>
             </goals>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,52 @@
+FROM jboss/base-jdk:8
+
+ENV KEYCLOAK_CUSTOMIZATIONS_LOCATION ${keycloak.customizations.location}
+ENV KEYCLOAK_VERSION ${keycloak.version}
+# Enables signals getting passed from startup script to JVM
+# ensuring clean shutdown when container is stopped.
+ENV LAUNCH_JBOSS_IN_BACKGROUND 1
+
+USER root
+
+RUN yum install -y epel-release && yum install -y jq && yum clean all
+
+RUN cd /opt/jboss/ && curl -L https://downloads.jboss.org/keycloak/${keycloak.version}/keycloak-${keycloak.version}.tar.gz | tar zx && mv /opt/jboss/keycloak-${keycloak.version} /opt/jboss/keycloak
+
+ADD docker-entrypoint.sh /opt/jboss/
+
+ADD setLogLevel.xsl /opt/jboss/keycloak/
+RUN java -jar /usr/share/java/saxon.jar -s:/opt/jboss/keycloak/standalone/configuration/standalone.xml -xsl:/opt/jboss/keycloak/setLogLevel.xsl -o:/opt/jboss/keycloak/standalone/configuration/standalone.xml
+RUN sed -i 's/\(logger.handlers=CONSOLE\),FILE/\1/' keycloak/standalone/configuration/logging.properties
+
+ENV JBOSS_HOME /opt/jboss/keycloak
+
+ADD $KEYCLOAK_CUSTOMIZATIONS_LOCATION/openshift-provider.jar /opt/jboss/keycloak/providers/
+ADD $KEYCLOAK_CUSTOMIZATIONS_LOCATION/ipaas-theme.jar /opt/jboss/keycloak/providers/
+ADD $KEYCLOAK_CUSTOMIZATIONS_LOCATION/autolink-idp.jar /opt/jboss/keycloak/providers/
+#ADD openshift-provider.jar /opt/jboss/keycloak/providers/
+#ADD ipaas-theme.jar /opt/jboss/keycloak/providers/
+#ADD autolink-idp.jar /opt/jboss/keycloak/providers/
+RUN mkdir -p /opt/jboss/keycloak/themes/keycloak/admin/resources/partials/ && \
+    cd /opt/jboss/keycloak/themes/keycloak/admin/resources/partials/ && \
+    unzip -j /opt/jboss/keycloak/providers/ipaas-theme.jar theme/ipaas/admin/resources/partials/realm-identity-provider-openshift.html theme/ipaas/admin/resources/partials/realm-identity-provider-openshift-ext.html && \
+    mkdir -p /opt/jboss/keycloak/themes/keycloak/admin/messages/ && \
+    cd /opt/jboss/keycloak/themes/keycloak/admin/messages/ && \
+    unzip -j /opt/jboss/keycloak/providers/ipaas-theme.jar theme/ipaas/admin/messages/admin-messages_en.properties && \
+    chmod g+rwX /opt/jboss/keycloak/providers/*.jar
+RUN cd /opt/jboss/keycloak/themes/ && \
+    unzip /opt/jboss/keycloak/providers/ipaas-theme.jar && \
+    mv theme/ipaas . && \
+    rm -rf theme META-INF
+
+RUN mkdir $JBOSS_HOME/standalone/{data,log} && \
+    chown -R jboss:root $JBOSS_HOME && \
+    find $JBOSS_HOME -type d -exec chmod 770 {} \; && \
+    find $JBOSS_HOME/standalone/configuration -type f -exec chmod 660 {} \;
+
+USER jboss
+
+EXPOSE 8080
+
+ENTRYPOINT [ "/opt/jboss/docker-entrypoint.sh" ]
+
+CMD ["-b", "0.0.0.0"]

--- a/src/main/docker/cccp.yml
+++ b/src/main/docker/cccp.yml
@@ -1,0 +1,3 @@
+# This is for the purpose of building container in
+# container pipeline
+job-id: keycloak

--- a/src/main/docker/docker-entrypoint.sh
+++ b/src/main/docker/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
+    keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
+fi
+
+exec /opt/jboss/keycloak/bin/standalone.sh $@

--- a/src/main/docker/setLogLevel.xsl
+++ b/src/main/docker/setLogLevel.xsl
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:log="urn:jboss:domain:logging:3.0">
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:template match="//log:subsystem">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+                <log:logger category="org.keycloak">
+                    <log:level>
+                      <xsl:attribute name="name">${env.KEYCLOAK_LOGLEVEL:INFO}</xsl:attribute>
+                    </log:level>
+                </log:logger>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="//log:handler[@name='FILE']" />
+
+    <xsl:template match="//log:periodic-rotating-file-handler[@name='FILE']" />
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Provides property substitution and a pom.xml so we can align the version coming from keycloak-customizations within the pipeline.